### PR TITLE
fix: add functionality for authentication #16

### DIFF
--- a/aas_python_http_client/api/aasx_file_server_api_api.py
+++ b/aas_python_http_client/api/aasx_file_server_api_api.py
@@ -107,7 +107,7 @@ class AASXFileServerAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/packages/{packageId}', 'DELETE',
@@ -200,7 +200,7 @@ class AASXFileServerAPIApi(object):
             ['application/asset-administration-shell-package', 'application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/packages/{packageId}', 'GET',
@@ -297,7 +297,7 @@ class AASXFileServerAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/packages', 'GET',
@@ -411,7 +411,7 @@ class AASXFileServerAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/packages', 'POST',
@@ -533,7 +533,7 @@ class AASXFileServerAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/packages/{packageId}', 'PUT',

--- a/aas_python_http_client/api/asset_administration_shell_api_api.py
+++ b/aas_python_http_client/api/asset_administration_shell_api_api.py
@@ -115,7 +115,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'DELETE',
@@ -208,7 +208,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}', 'DELETE',
@@ -309,7 +309,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'DELETE',
@@ -402,7 +402,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodel-refs/{submodelIdentifier}', 'DELETE',
@@ -487,7 +487,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/asset-information/thumbnail', 'DELETE',
@@ -596,7 +596,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements', 'GET',
@@ -701,7 +701,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/$metadata', 'GET',
@@ -806,7 +806,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/$path', 'GET',
@@ -911,7 +911,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/$reference', 'GET',
@@ -1020,7 +1020,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/$value', 'GET',
@@ -1113,7 +1113,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodel-refs', 'GET',
@@ -1198,7 +1198,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas', 'GET',
@@ -1283,7 +1283,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/$reference', 'GET',
@@ -1368,7 +1368,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/asset-information', 'GET',
@@ -1469,7 +1469,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/octet-stream', 'application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'GET',
@@ -1586,7 +1586,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}', 'GET',
@@ -1703,7 +1703,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value', 'GET',
@@ -1820,7 +1820,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}', 'GET',
@@ -1921,7 +1921,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}', 'GET',
@@ -2030,7 +2030,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'GET',
@@ -2135,7 +2135,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$metadata', 'GET',
@@ -2240,7 +2240,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$path', 'GET',
@@ -2345,7 +2345,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$reference', 'GET',
@@ -2450,7 +2450,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$value', 'GET',
@@ -2547,7 +2547,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/$metadata', 'GET',
@@ -2644,7 +2644,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/$reference', 'GET',
@@ -2741,7 +2741,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/$path', 'GET',
@@ -2842,7 +2842,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/$value', 'GET',
@@ -2927,7 +2927,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/octet-stream', 'application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/asset-information/thumbnail', 'GET',
@@ -3040,7 +3040,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async', 'POST',
@@ -3153,7 +3153,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-asnyc/$value', 'POST',
@@ -3266,7 +3266,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke', 'POST',
@@ -3379,7 +3379,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value', 'POST',
@@ -3488,7 +3488,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}', 'PATCH',
@@ -3605,7 +3605,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'PATCH',
@@ -3722,7 +3722,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$metadata', 'PATCH',
@@ -3839,7 +3839,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$value', 'PATCH',
@@ -3948,7 +3948,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/$metadata', 'PATCH',
@@ -4057,7 +4057,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/$value', 'PATCH',
@@ -4162,7 +4162,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements', 'POST',
@@ -4275,7 +4275,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'POST',
@@ -4372,7 +4372,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodel-refs', 'POST',
@@ -4469,7 +4469,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas', 'PUT',
@@ -4566,7 +4566,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/asset-information', 'PUT',
@@ -4687,7 +4687,7 @@ class AssetAdministrationShellAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'PUT',
@@ -4796,7 +4796,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}', 'PUT',
@@ -4909,7 +4909,7 @@ class AssetAdministrationShellAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'PUT',
@@ -5014,7 +5014,7 @@ class AssetAdministrationShellAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/aas/asset-information/thumbnail', 'PUT',

--- a/aas_python_http_client/api/asset_administration_shell_basic_discovery_api_api.py
+++ b/aas_python_http_client/api/asset_administration_shell_basic_discovery_api_api.py
@@ -107,7 +107,7 @@ class AssetAdministrationShellBasicDiscoveryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/lookup/shells/{aasIdentifier}', 'DELETE',
@@ -205,7 +205,7 @@ class AssetAdministrationShellBasicDiscoveryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/lookup/shells', 'GET',
@@ -298,7 +298,7 @@ class AssetAdministrationShellBasicDiscoveryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/lookup/shells/{aasIdentifier}', 'GET',
@@ -403,7 +403,7 @@ class AssetAdministrationShellBasicDiscoveryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/lookup/shells/{aasIdentifier}', 'POST',

--- a/aas_python_http_client/api/asset_administration_shell_registry_api_api.py
+++ b/aas_python_http_client/api/asset_administration_shell_registry_api_api.py
@@ -107,7 +107,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}', 'DELETE',
@@ -208,7 +208,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}', 'DELETE',
@@ -309,7 +309,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors', 'GET',
@@ -410,7 +410,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}/submodel-descriptors', 'GET',
@@ -503,7 +503,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}', 'GET',
@@ -604,7 +604,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}', 'GET',
@@ -701,7 +701,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors', 'POST',
@@ -806,7 +806,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}/submodel-descriptors', 'POST',
@@ -911,7 +911,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}', 'PUT',
@@ -1024,7 +1024,7 @@ class AssetAdministrationShellRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}', 'PUT',

--- a/aas_python_http_client/api/asset_administration_shell_repository_api_api.py
+++ b/aas_python_http_client/api/asset_administration_shell_repository_api_api.py
@@ -107,9 +107,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
-        if self.api_client.configuration.username != '' and self.api_client.configuration.password != '':
-            auth_settings = ['basic_auth']
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()  # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}', 'DELETE',
@@ -218,7 +216,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'DELETE',
@@ -319,7 +317,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}', 'DELETE',
@@ -428,7 +426,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'DELETE',
@@ -529,7 +527,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodel-refs/{submodelIdentifier}', 'DELETE',
@@ -622,7 +620,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/asset-information/thumbnail', 'DELETE',
@@ -724,7 +722,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells', 'GET',
@@ -826,7 +824,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/$reference', 'GET',
@@ -943,7 +941,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements', 'GET',
@@ -1056,7 +1054,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/$metadata', 'GET',
@@ -1173,7 +1171,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/$path', 'GET',
@@ -1286,7 +1284,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/$reference', 'GET',
@@ -1399,7 +1397,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/$value', 'GET',
@@ -1500,7 +1498,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodel-refs', 'GET',
@@ -1593,7 +1591,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}', 'GET',
@@ -1686,7 +1684,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/$reference', 'GET',
@@ -1779,7 +1777,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/asset-information', 'GET',
@@ -1888,7 +1886,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/octet-stream', 'application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'GET',
@@ -2005,7 +2003,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}', 'GET',
@@ -2122,7 +2120,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value', 'GET',
@@ -2239,7 +2237,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}', 'GET',
@@ -2348,7 +2346,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}', 'GET',
@@ -2453,7 +2451,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/$metadata', 'GET',
@@ -2558,7 +2556,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/$path', 'GET',
@@ -2659,7 +2657,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/$reference', 'GET',
@@ -2768,7 +2766,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/$value', 'GET',
@@ -2885,7 +2883,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'GET',
@@ -2998,7 +2996,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$metadata', 'GET',
@@ -3111,7 +3109,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$path', 'GET',
@@ -3224,7 +3222,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$reference', 'GET',
@@ -3341,7 +3339,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$value', 'GET',
@@ -3434,7 +3432,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/octet-stream', 'application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/asset-information/thumbnail', 'GET',
@@ -3555,7 +3553,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke', 'POST',
@@ -3676,7 +3674,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async', 'POST',
@@ -3797,7 +3795,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value', 'POST',
@@ -3918,7 +3916,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value', 'POST',
@@ -4035,7 +4033,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}', 'PATCH',
@@ -4152,7 +4150,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/$metadata', 'PATCH',
@@ -4269,7 +4267,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/$value', 'PATCH',
@@ -4394,7 +4392,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'PATCH',
@@ -4519,7 +4517,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$metadata', 'PATCH',
@@ -4644,7 +4642,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$value', 'PATCH',
@@ -4741,9 +4739,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
-        if self.api_client.configuration.username != '' and self.api_client.configuration.password != '':
-            auth_settings = ['basic_auth']
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells', 'POST',
@@ -4856,7 +4852,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements', 'POST',
@@ -4977,7 +4973,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'POST',
@@ -5082,7 +5078,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodel-refs', 'POST',
@@ -5187,7 +5183,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}', 'PUT',
@@ -5292,7 +5288,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/asset-information', 'PUT',
@@ -5421,7 +5417,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'PUT',
@@ -5534,7 +5530,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}', 'PUT',
@@ -5655,7 +5651,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'PUT',
@@ -5768,7 +5764,7 @@ class AssetAdministrationShellRepositoryAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}/asset-information/thumbnail', 'PUT',

--- a/aas_python_http_client/api/asset_administration_shell_repository_api_api.py
+++ b/aas_python_http_client/api/asset_administration_shell_repository_api_api.py
@@ -108,6 +108,8 @@ class AssetAdministrationShellRepositoryAPIApi(object):
 
         # Authentication setting
         auth_settings = []  # noqa: E501
+        if self.api_client.configuration.username != '' and self.api_client.configuration.password != '':
+            auth_settings = ['basic_auth']
 
         return self.api_client.call_api(
             '/shells/{aasIdentifier}', 'DELETE',
@@ -4740,6 +4742,8 @@ class AssetAdministrationShellRepositoryAPIApi(object):
 
         # Authentication setting
         auth_settings = []  # noqa: E501
+        if self.api_client.configuration.username != '' and self.api_client.configuration.password != '':
+            auth_settings = ['basic_auth']
 
         return self.api_client.call_api(
             '/shells', 'POST',

--- a/aas_python_http_client/api/concept_description_repository_api_api.py
+++ b/aas_python_http_client/api/concept_description_repository_api_api.py
@@ -107,7 +107,7 @@ class ConceptDescriptionRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/concept-descriptions/{cdIdentifier}', 'DELETE',
@@ -212,7 +212,7 @@ class ConceptDescriptionRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/concept-descriptions', 'GET',
@@ -305,7 +305,7 @@ class ConceptDescriptionRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/concept-descriptions/{cdIdentifier}', 'GET',
@@ -402,7 +402,7 @@ class ConceptDescriptionRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/concept-descriptions', 'POST',
@@ -507,7 +507,7 @@ class ConceptDescriptionRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/concept-descriptions/{cdIdentifier}', 'PUT',

--- a/aas_python_http_client/api/description_api_api.py
+++ b/aas_python_http_client/api/description_api_api.py
@@ -99,7 +99,7 @@ class DescriptionAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/description', 'GET',

--- a/aas_python_http_client/api/serialization_api_api.py
+++ b/aas_python_http_client/api/serialization_api_api.py
@@ -113,7 +113,7 @@ class SerializationAPIApi(object):
             ['application/asset-administration-shell-package+xml', 'application/json', 'application/xml'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/serialization', 'GET',

--- a/aas_python_http_client/api/submodel_api_api.py
+++ b/aas_python_http_client/api/submodel_api_api.py
@@ -107,7 +107,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/attachment', 'DELETE',
@@ -200,7 +200,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}', 'DELETE',
@@ -301,7 +301,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements', 'GET',
@@ -398,7 +398,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/$metadata', 'GET',
@@ -495,7 +495,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/$path', 'GET',
@@ -592,7 +592,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/$reference', 'GET',
@@ -693,7 +693,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/$value', 'GET',
@@ -786,7 +786,7 @@ class SubmodelAPIApi(object):
             ['application/octet-stream', 'application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/attachment', 'GET',
@@ -887,7 +887,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/operation-results/{handleId}', 'GET',
@@ -988,7 +988,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/operation-results/{handleId}/$value', 'GET',
@@ -1089,7 +1089,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/operation-status/{handleId}', 'GET',
@@ -1182,7 +1182,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel', 'GET',
@@ -1283,7 +1283,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}', 'GET',
@@ -1380,7 +1380,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/$metadata', 'GET',
@@ -1477,7 +1477,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/$path', 'GET',
@@ -1574,7 +1574,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/$reference', 'GET',
@@ -1675,7 +1675,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/$value', 'GET',
@@ -1764,7 +1764,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/$metadata', 'GET',
@@ -1853,7 +1853,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/$path', 'GET',
@@ -1942,7 +1942,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/$reference', 'GET',
@@ -2035,7 +2035,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/$value', 'GET',
@@ -2140,7 +2140,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/invoke', 'POST',
@@ -2245,7 +2245,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/invoke-async', 'POST',
@@ -2350,7 +2350,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/invoke-async/$value', 'POST',
@@ -2455,7 +2455,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/invoke/$value', 'POST',
@@ -2556,7 +2556,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel', 'PATCH',
@@ -2665,7 +2665,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}', 'PATCH',
@@ -2782,7 +2782,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/$metadata', 'PATCH',
@@ -2899,7 +2899,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/$value', 'PATCH',
@@ -3000,7 +3000,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/$metadata', 'PATCH',
@@ -3101,7 +3101,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/$value', 'PATCH',
@@ -3198,7 +3198,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements', 'POST',
@@ -3303,7 +3303,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}', 'POST',
@@ -3416,7 +3416,7 @@ class SubmodelAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}/attachment', 'PUT',
@@ -3517,7 +3517,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel', 'PUT',
@@ -3626,7 +3626,7 @@ class SubmodelAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel/submodel-elements/{idShortPath}', 'PUT',

--- a/aas_python_http_client/api/submodel_registry_api_api.py
+++ b/aas_python_http_client/api/submodel_registry_api_api.py
@@ -107,7 +107,7 @@ class SubmodelRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel-descriptors/{submodelIdentifier}', 'DELETE',
@@ -200,7 +200,7 @@ class SubmodelRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel-descriptors', 'GET',
@@ -293,7 +293,7 @@ class SubmodelRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel-descriptors/{submodelIdentifier}', 'GET',
@@ -390,7 +390,7 @@ class SubmodelRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel-descriptors', 'POST',
@@ -495,7 +495,7 @@ class SubmodelRegistryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodel-descriptors/{submodelIdentifier}', 'PUT',

--- a/aas_python_http_client/api/submodel_repository_api_api.py
+++ b/aas_python_http_client/api/submodel_repository_api_api.py
@@ -115,7 +115,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'DELETE',
@@ -208,7 +208,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}', 'DELETE',
@@ -309,7 +309,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'DELETE',
@@ -414,7 +414,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/$metadata', 'GET',
@@ -519,7 +519,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/$path', 'GET',
@@ -624,7 +624,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/$reference', 'GET',
@@ -733,7 +733,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements', 'GET',
@@ -842,7 +842,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/$value', 'GET',
@@ -951,7 +951,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels', 'GET',
@@ -1056,7 +1056,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/$metadata', 'GET',
@@ -1161,7 +1161,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/$path', 'GET',
@@ -1266,7 +1266,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/$reference', 'GET',
@@ -1375,7 +1375,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/$value', 'GET',
@@ -1476,7 +1476,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/octet-stream', 'application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'GET',
@@ -1585,7 +1585,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}', 'GET',
@@ -1694,7 +1694,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value', 'GET',
@@ -1803,7 +1803,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}', 'GET',
@@ -1904,7 +1904,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}', 'GET',
@@ -2001,7 +2001,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/$metadata', 'GET',
@@ -2098,7 +2098,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/$path', 'GET',
@@ -2191,7 +2191,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/$reference', 'GET',
@@ -2292,7 +2292,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/$value', 'GET',
@@ -2397,7 +2397,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$metadata', 'GET',
@@ -2502,7 +2502,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$path', 'GET',
@@ -2607,7 +2607,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$reference', 'GET',
@@ -2716,7 +2716,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'GET',
@@ -2825,7 +2825,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$value', 'GET',
@@ -2938,7 +2938,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async', 'POST',
@@ -3059,7 +3059,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value', 'POST',
@@ -3176,7 +3176,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke', 'POST',
@@ -3301,7 +3301,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value', 'POST',
@@ -3410,7 +3410,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}', 'PATCH',
@@ -3519,7 +3519,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/$metadata', 'PATCH',
@@ -3628,7 +3628,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/$value', 'PATCH',
@@ -3745,7 +3745,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$metadata', 'PATCH',
@@ -3862,7 +3862,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'PATCH',
@@ -3979,7 +3979,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/$value', 'PATCH',
@@ -4076,7 +4076,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels', 'POST',
@@ -4189,7 +4189,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'POST',
@@ -4294,7 +4294,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements', 'POST',
@@ -4415,7 +4415,7 @@ class SubmodelRepositoryAPIApi(object):
             ['multipart/form-data'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/attachment', 'PUT',
@@ -4520,7 +4520,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}', 'PUT',
@@ -4637,7 +4637,7 @@ class SubmodelRepositoryAPIApi(object):
             ['application/json'])  # noqa: E501
 
         # Authentication setting
-        auth_settings = []  # noqa: E501
+        auth_settings = self.api_client.configuration.get_auth_settings_keys()   # noqa: E501
 
         return self.api_client.call_api(
             '/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}', 'PUT',

--- a/aas_python_http_client/configuration.py
+++ b/aas_python_http_client/configuration.py
@@ -231,7 +231,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
 
         :return: The Auth Settings information dict.
         """
-        return {
+        return {'basic_auth': {'in': 'header', 'key': 'Authorization', 'value': self.get_basic_auth_token()}
         }
 
     def to_debug_report(self):

--- a/aas_python_http_client/configuration.py
+++ b/aas_python_http_client/configuration.py
@@ -226,6 +226,16 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
             ).get('authorization')
         return token
 
+    def get_auth_settings_keys(self):
+        """Gets Keys of Auth Settings.
+
+        :return: The Auth Settings keys.
+        """
+        auth_setting = []
+        if self.username or self.password:
+            auth_setting.append('basic_auth')
+        return auth_setting
+
     def auth_settings(self):
         """Gets Auth Settings dict for api client.
 


### PR DESCRIPTION
## Issue
Server authentication was not possible in the following functions:
- `post_asset_administration_shell`
- `delete_asset_administration_shell_by_id`

## Fix
- Added a dictionary entry in `auth_settings`.
- Updated both functions to include basic authentication in the request.