### PR TITLE
Fix LangString subclasses dropping 'text' during deserialization

### DIFF
--- a/aas_python_http_client/models/lang_string_definition_type_iec61360.py
+++ b/aas_python_http_client/models/lang_string_definition_type_iec61360.py
@@ -44,9 +44,9 @@ class LangStringDefinitionTypeIec61360(AbstractLangString):
         """LangStringDefinitionTypeIec61360 - a model defined in Swagger"""  # noqa: E501
         self._text = None
         self.discriminator = None
+        AbstractLangString.__init__(self, *args, **kwargs)
         if text is not None:
             self.text = text
-        AbstractLangString.__init__(self, *args, **kwargs)
 
     @property
     def text(self):

--- a/aas_python_http_client/models/lang_string_name_type.py
+++ b/aas_python_http_client/models/lang_string_name_type.py
@@ -44,9 +44,9 @@ class LangStringNameType(AbstractLangString):
         """LangStringNameType - a model defined in Swagger"""  # noqa: E501
         self._text = None
         self.discriminator = None
+        AbstractLangString.__init__(self, *args, **kwargs)
         if text is not None:
             self.text = text
-        AbstractLangString.__init__(self, *args, **kwargs)
 
     @property
     def text(self):

--- a/aas_python_http_client/models/lang_string_preferred_name_type_iec61360.py
+++ b/aas_python_http_client/models/lang_string_preferred_name_type_iec61360.py
@@ -44,9 +44,9 @@ class LangStringPreferredNameTypeIec61360(AbstractLangString):
         """LangStringPreferredNameTypeIec61360 - a model defined in Swagger"""  # noqa: E501
         self._text = None
         self.discriminator = None
+        AbstractLangString.__init__(self, *args, **kwargs)
         if text is not None:
             self.text = text
-        AbstractLangString.__init__(self, *args, **kwargs)
 
     @property
     def text(self):

--- a/aas_python_http_client/models/lang_string_short_name_type_iec61360.py
+++ b/aas_python_http_client/models/lang_string_short_name_type_iec61360.py
@@ -44,9 +44,9 @@ class LangStringShortNameTypeIec61360(AbstractLangString):
         """LangStringShortNameTypeIec61360 - a model defined in Swagger"""  # noqa: E501
         self._text = None
         self.discriminator = None
+        AbstractLangString.__init__(self, *args, **kwargs)
         if text is not None:
             self.text = text
-        AbstractLangString.__init__(self, *args, **kwargs)
 
     @property
     def text(self):

--- a/aas_python_http_client/models/lang_string_text_type.py
+++ b/aas_python_http_client/models/lang_string_text_type.py
@@ -44,9 +44,9 @@ class LangStringTextType(AbstractLangString):
         """LangStringTextType - a model defined in Swagger"""  # noqa: E501
         self._text = None
         self.discriminator = None
+        AbstractLangString.__init__(self, *args, **kwargs)
         if text is not None:
             self.text = text
-        AbstractLangString.__init__(self, *args, **kwargs)
 
     @property
     def text(self):


### PR DESCRIPTION
Subclass` __init__` set `self.text` before calling `AbstractLangString.__init__`, which then reset it via its own `text=None` default.
Deserialized `langStrings` lost their 'text' (e.g. descriptor description/displayName). 
Call super first, then assign text.